### PR TITLE
Older firefox compatibility

### DIFF
--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -96,9 +96,13 @@
   if (NativeIteratorPrototype &&
       NativeIteratorPrototype !== Op &&
       hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
-    // This environment has a native %IteratorPrototype%; use it instead
-    // of the polyfill.
-    IteratorPrototype = NativeIteratorPrototype;
+    // This environment has a native %IteratorPrototype%; use it instead of the
+    // polyfill unless it's the broken Firefox IteratorPrototype. See
+    // https://github.com/facebook/regenerator/issues/274 for more details.
+    var _n = NativeIteratorPrototype[iteratorSymbol].call(NativeIteratorPrototype);
+    if (!_n || !_n.next || _n.next.name !== 'LegacyIteratorNext') {
+      IteratorPrototype = NativeIteratorPrototype;
+    }
   }
 
   var Gp = GeneratorFunctionPrototype.prototype =

--- a/packages/regenerator-runtime/runtime.js
+++ b/packages/regenerator-runtime/runtime.js
@@ -96,13 +96,9 @@
   if (NativeIteratorPrototype &&
       NativeIteratorPrototype !== Op &&
       hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
-    // This environment has a native %IteratorPrototype%; use it instead of the
-    // polyfill unless it's the broken Firefox IteratorPrototype. See
-    // https://github.com/facebook/regenerator/issues/274 for more details.
-    var _n = NativeIteratorPrototype[iteratorSymbol].call(NativeIteratorPrototype);
-    if (!_n || !_n.next || _n.next.name !== 'LegacyIteratorNext') {
-      IteratorPrototype = NativeIteratorPrototype;
-    }
+    // This environment has a native %IteratorPrototype%; use it instead
+    // of the polyfill.
+    IteratorPrototype = NativeIteratorPrototype;
   }
 
   var Gp = GeneratorFunctionPrototype.prototype =
@@ -395,6 +391,15 @@
   defineIteratorMethods(Gp);
 
   Gp[toStringTagSymbol] = "Generator";
+
+  // A Generator should always return itself as the iterator object when the
+  // @@iterator function is called on it. Some browsers' implementations of the
+  // iterator prototype chain incorrectly implement this, causing the Generator
+  // object to not be returned from this call. This ensures that doesn't happen.
+  // See https://github.com/facebook/regenerator/issues/274 for more details.
+  Gp[iteratorSymbol] = function() {
+    return this;
+  };
 
   Gp.toString = function() {
     return "[object Generator]";


### PR DESCRIPTION
The quick fix for FF <= 45 related to the problem with `yield*`. Issue is related to problem with `universal-route` (https://github.com/kriasoft/universal-router/blob/master/src/matchRoute.js#L43). 

More information about problem you can find here https://github.com/facebook/regenerator/pull/278